### PR TITLE
Fixed links and text.

### DIFF
--- a/frameworks.html
+++ b/frameworks.html
@@ -135,7 +135,7 @@
 				Schnapp et al’s MIT <a href="http://jeffreyschnapp.com/wp-content/uploads/2013/01/D_H_ShortGuide.pdf" target="_blank">Short Guide to Digital Humanities</a> outlines a framework for competencies and learning outcomes that we find particularly helpful for the presentation of not just digital skills to be mastered but more importantly of the crucial merging of those skills into the intellectual work of the course or learning experience. We believe the division of competencies into Technical, Administrative, and Intellectual can be helpful for the formation or revision of other disciplinary or professional digital literacy standards. 
 			</p>
 			<p>
-			<a href="http://ccnmtl.github.io/diglit-cognitive-badge" target="_blank" class="btn btn-secondary">
+			<a href="http://ccnmtl.github.io/diglit-dh-badge" target="_blank" class="btn btn-secondary">
 				Explore Framework
 			</a>
 			</p>
@@ -144,13 +144,13 @@
 	
 		<div class="col-md-4">
 			<h2>
-				Eshet
+				Eshet's Cognitive Skills
 			</h2>
 			<p>
 				Yoram Eshet’s <a href="http://iisit.org/Vol9/IISITv9p267-276Eshet021.pdf" target="_blank">cognitive skills framework</a> (rev. 2012) posits six skills that are unique to the digital realm. We find it provides an excellent framework for representing the kinds of general digital skills and methods now commonly taught as part of many educational experiences. To help instructors apply this framework to their work, we have created a <a href="http://edblogs.columbia.edu/teaching-dig-lit/resources/cognitive-digital-skills-matrix/" target="_blank">version</a> built out along our modified three Bloom’s levels and provided examples of common activities at each level. 
 			</p>
 			<p>
-			<a href="http://ccnmtl.github.io/diglit-dh-badge/" target="_blank" class="btn btn-secondary">
+			<a href="http://ccnmtl.github.io/diglit-cognitive-badge/" target="_blank" class="btn btn-secondary">
 				Explore Framework
 			</a>
 			</p>


### PR DESCRIPTION
Link to DH and Cognitive frameworks were switched - corrected.
Changed name of Eshet framework.